### PR TITLE
Replace reference pass with interface when enabling vision

### DIFF
--- a/app/src/main/java/com/obruta/astrosee/AstroseeNode.java
+++ b/app/src/main/java/com/obruta/astrosee/AstroseeNode.java
@@ -112,7 +112,7 @@ public class AstroseeNode extends AbstractNodeMain {
 
         this.context = applicationContext;
         this.saveImages = false;
-        this.processImages = true;
+        this.processImages = false;
 
 
         paint = new Paint();
@@ -463,6 +463,9 @@ public class AstroseeNode extends AbstractNodeMain {
                 if (!processImages) {
                     return;
                 }
+                //String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmssSSS",
+                //        Locale.getDefault()).format(new Date());
+                //Log.i(TAG, "Processing image at " + timestamp);
                 // Image to bitmap
                 ChannelBuffer buffer = image.getData();
                 byte[] data = buffer.array();

--- a/app/src/main/java/com/obruta/astrosee/AstroseeServiceListener.java
+++ b/app/src/main/java/com/obruta/astrosee/AstroseeServiceListener.java
@@ -1,0 +1,5 @@
+package com.obruta.astrosee;
+
+public interface AstroseeServiceListener {
+    void onVisionEnable(boolean enable);
+}

--- a/app/src/main/java/com/obruta/astrosee/MainActivity.java
+++ b/app/src/main/java/com/obruta/astrosee/MainActivity.java
@@ -25,7 +25,7 @@ import java.net.URI;
 
 import gov.nasa.arc.astrobee.android.gs.MessageType;
 
-public class MainActivity extends RosActivity {
+public class MainActivity extends RosActivity implements AstroseeServiceListener {
     // IP Address ROS Master
     private static final URI ROS_MASTER_URI = URI.create("http://llp:11311");
     private static final String TAG = MainActivity.class.getSimpleName();
@@ -36,17 +36,12 @@ public class MainActivity extends RosActivity {
     private Handler handler;
     private AstroseeNode node;
 
-    // Method to get the AstroseeNode instance
-    public AstroseeNode getAstroseeNode() {
-        return node;
-    }
-
     private ServiceConnection serviceConnection = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName name, IBinder service) {
             StartAstroseeService.LocalBinder binder = (StartAstroseeService.LocalBinder) service;
             gsService = binder.getService();
-            gsService.setAstroseeNode(node); // Set the AstroseeNode instance in the service
+            gsService.setListener(MainActivity.this);
             isBound = true;
         }
 
@@ -135,5 +130,10 @@ public class MainActivity extends RosActivity {
 
         // Start the handler
         handler.sendEmptyMessage(0);
+    }
+
+    @Override
+    public void onVisionEnable(boolean enable) {
+        node.enableImageProcessing(enable);
     }
 }

--- a/app/src/main/java/com/obruta/astrosee/StartAstroseeService.java
+++ b/app/src/main/java/com/obruta/astrosee/StartAstroseeService.java
@@ -3,6 +3,7 @@ package com.obruta.astrosee;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.IBinder;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -27,13 +28,11 @@ public class StartAstroseeService extends StartGuestScienceService {
         }
     }
 
-    private AstroseeNode astroseeNode;
+    private AstroseeServiceListener listener;
 
-    // Method to set the AstroseeNode instance
-    public void setAstroseeNode(AstroseeNode node) {
-        astroseeNode = node;
+    public void setListener(AstroseeServiceListener listener) {
+        this.listener = listener;
     }
-
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -55,9 +54,6 @@ public class StartAstroseeService extends StartGuestScienceService {
 
         // Inform the GS Manager and the GDS that the app has been started.
         sendStarted("info");
-
-        // Start with vision disabled
-        astroseeNode.enableImageProcessing(false); // Disable the vision
     }
 
     /**
@@ -96,22 +92,26 @@ public class StartAstroseeService extends StartGuestScienceService {
             // Get the name of the command we received. See commands.xml files in res folder.
             String sCommand = jCommand.getString("name");
 
+            Log.i(TAG, "Received command: " + sCommand);
+
             // JSON object that will contain the data we will send back to the GSM and GDS
             JSONObject jResult = new JSONObject();
 
             switch (sCommand) {
                 // You may handle your commands here
                 case "start_vision":
-                    astroseeNode.enableImageProcessing(true); // Enable the vision
+                    listener.onVisionEnable(true);
                     jResult.put("Summary", new JSONObject()
                             .put("Status", "OK")
                             .put("Message", "Vision Started"));
+                    Log.i(TAG, "Executed start_vision");
                     break;
                 case "stop_vision":
-                    astroseeNode.enableImageProcessing(false); // Disable the vision
+                    listener.onVisionEnable(false);
                     jResult.put("Summary", new JSONObject()
                             .put("Status", "OK")
                             .put("Message", "Vision Stopped"));
+                    Log.i(TAG, "Executed stop_vision");
                     break;
                 default:
                     // Inform GS Manager and GDS, then stop execution.


### PR DESCRIPTION
Previous method was hanging the APK. This implements the use of an interface as a callback method to access the node from the service.